### PR TITLE
Update yarn.lock for new SWC packages and enhance FormDeliveryInforma…

### DIFF
--- a/src/sections/tao-don/FormDeliveryInformationVNHan.tsx
+++ b/src/sections/tao-don/FormDeliveryInformationVNHan.tsx
@@ -4,6 +4,7 @@ import {Button} from '@/components/ui/button'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -138,6 +139,10 @@ export default function FormDeliveryInformationVNHan({
                     {...field}
                   />
                 </FormControl>
+                <FormDescription className='pl-[0.75rem] text-pc-sub12m text-[rgba(0,0,0,0.60)] !mt-[0.25rem]'>
+                  *Tên người nhận phải trùng khớp với mã thông quan, nếu không
+                  khớp sẽ giao sai.
+                </FormDescription>
                 <FormMessage className='pl-[0.75rem] xsm:text-mb-sub10m xsm:mt-[0.25rem] !text-[#F00] text-pc-sub12m' />
               </FormItem>
             )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,10 +151,15 @@
   dependencies:
     glob "10.3.10"
 
-"@next/swc-darwin-arm64@14.2.18":
+"@next/swc-linux-x64-gnu@14.2.18":
   version "14.2.18"
-  resolved "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.18.tgz"
-  integrity sha512-tOBlDHCjGdyLf0ube/rDUs6VtwNOajaWV+5FV/ajPgrvHeisllEdymY/oDgv2cx561+gJksfMUtqf8crug7sbA==
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.18.tgz"
+  integrity sha512-3kmv8DlyhPRCEBM1Vavn8NjyXtMeQ49ID0Olr/Sut7pgzaQTo4h01S7Z8YNE0VtbowyuAL26ibcz0ka6xCTH5g==
+
+"@next/swc-linux-x64-musl@14.2.18":
+  version "14.2.18"
+  resolved "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.18.tgz"
+  integrity sha512-mliTfa8seVSpTbVEcKEXGjC18+TDII8ykW4a36au97spm9XMPqQTpdGPNBJ9RySSFw9/hLuaCMByluQIAnkzlw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
…tionVNHan with validation message

- Replaced the darwin-arm64 SWC package with linux-x64-gnu and added linux-x64-musl package in yarn.lock.
- Added FormDescription to FormDeliveryInformationVNHan to provide user guidance on recipient name validation.